### PR TITLE
✨ Add domain prefixes to social media fields where appropriate

### DIFF
--- a/src/components/ticker/TickerForm.tsx
+++ b/src/components/ticker/TickerForm.tsx
@@ -186,8 +186,9 @@ const TickerForm: FC<Props> = ({ callback, id, ticker }) => {
               {...register('information.twitter')}
               InputProps={{
                 startAdornment: (
-                  <InputAdornment position="start">
+                  <InputAdornment position="start" style={{ marginRight: '0px' }}>
                     <FontAwesomeIcon icon={faTwitter} />
+                    <span style={{ paddingLeft: '8px' }}>twitter.com/</span>
                   </InputAdornment>
                 ),
               }}
@@ -202,8 +203,9 @@ const TickerForm: FC<Props> = ({ callback, id, ticker }) => {
               {...register('information.facebook')}
               InputProps={{
                 startAdornment: (
-                  <InputAdornment position="start">
+                  <InputAdornment position="start" style={{ marginRight: '0px' }}>
                     <FontAwesomeIcon icon={faFacebook} />
+                    <span style={{ paddingLeft: '8px' }}>fb.com/</span>
                   </InputAdornment>
                 ),
               }}
@@ -218,8 +220,9 @@ const TickerForm: FC<Props> = ({ callback, id, ticker }) => {
               {...register('information.telegram')}
               InputProps={{
                 startAdornment: (
-                  <InputAdornment position="start">
+                  <InputAdornment position="start" style={{ marginRight: '0px' }}>
                     <FontAwesomeIcon icon={faTelegram} />
+                    <span style={{ paddingLeft: '8px' }}>t.me/</span>
                   </InputAdornment>
                 ),
               }}


### PR DESCRIPTION
Makes it explicit that only the account/channel name is expected in some of the social media information fields.

## Screenshots

| Before | After |
| --- | --- |
| ![grafik](https://github.com/systemli/ticker-admin/assets/25278864/747357ab-c271-4c0c-b885-3f968ce0d291) | ![grafik](https://github.com/systemli/ticker-admin/assets/25278864/d8e6dd6d-68b3-4045-ae91-b68e3a3abc43) |