### PR TITLE
📝 Point README at central documentation and fix the nginx proxy template

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+.idea
+.vscode
+.DS_Store
+
+node_modules
+dist
+coverage
+site
+
+.env
+.env.*
+!.env.test
+
+npm-debug.log*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,9 @@
 ## Project Overview
 
 React 19 admin UI for the [systemli/ticker](https://github.com/systemli/ticker) backend.
-Built with TypeScript (strict), Vite 7, MUI 7, TanStack React Query 5, react-hook-form 7,
-react-router 7, and i18next. Node 22 (see `.nvmrc`), npm as package manager.
+Built with TypeScript (strict), Vite, MUI, TanStack React Query, react-hook-form,
+react-router, and i18next. See `package.json` for versions. Node 24 (see `.nvmrc`), npm as
+package manager (`package-lock.json`; do not use yarn).
 
 ## Commands
 
@@ -43,8 +44,8 @@ Configured in `.prettierrc.json`:
 - **Trailing commas (ES5)**
 - **No parens for single arrow params** (`x => x`, not `(x) => x`)
 
-ESLint (`.eslintrc.cjs`): `eslint:recommended` + `@typescript-eslint/recommended` +
-`react-hooks/recommended` + `react-refresh/only-export-components` (warn).
+ESLint (`eslint.config.js`, flat config): `eslint:recommended` + `typescript-eslint`
+recommended + `react-hooks/recommended` + `react-refresh/only-export-components` (warn).
 
 ## TypeScript Conventions
 
@@ -155,31 +156,72 @@ describe('ComponentName', () => {
 - Prefixed with `TICKER_` for Vite exposure (configured in `vite.config.ts`)
 - `TICKER_API_URL` — backend API base URL (see `.env` and `.env.test`)
 
-## Commit Conventions
+## Commits and Pull Requests
 
-- Commit messages **start with a Unicode Gitmoji** followed by a space and a short description
-- Reference: https://gitmoji.dev/
-- Examples:
-  - `✨ Add ticker filter component`
-  - `🐛 Fix message form validation`
-  - `♻️ Refactor API error handling`
-  - `🧪 Add tests for TickerList`
-  - `⬆️ Upgrade MUI to v7.3`
+### Commit messages
 
-## Pull Requests
+Start every commit with a [Gitmoji](https://gitmoji.dev/), followed by a space and a short
+description in the imperative mood. Use the **Unicode emoji**, not the `:shortcode:` form — both
+occur in the history, but new commits should use the emoji.
 
-PRs must be labeled for the release-drafter (`.github/release-drafter.yml`).
-The label determines the version bump and changelog category:
+| Emoji | Use for |
+| ----- | ------- |
+| ✨ | New feature |
+| 🐛 | Bug fix |
+| 🩹 | Minor, non-critical fix |
+| ♻️ | Refactor |
+| ✅ | Add, update or pass tests |
+| 🧪 | Add a deliberately failing test |
+| 📝 | Documentation |
+| ⬆️ | Upgrade dependencies |
+| ➖ | Remove a dependency |
+| 🔥 | Remove code or files |
+| 👷 | CI / build system |
+| 🔧 | Configuration files |
+| 🚨 | Fix linter or compiler warnings |
+| ⚡️ | Performance |
+| 🔒️ | Security fix |
+| 🗃️ | Database schema or storage changes |
+| 🔊 | Logging |
+| 💄 | UI and styling |
+| 🌐 | Internationalization and localization |
 
-| Label                   | Category    | Version bump |
-| ----------------------- | ----------- | ------------ |
-| `feature`               | Features    | major        |
-| `enhancement`           | Features    | minor        |
-| `fix`, `bugfix`, `bug`  | Bug Fixes   | patch        |
-| `chore`, `dependencies` | Maintenance | patch        |
+Examples:
+
+```
+✨ Add Bluesky reply restrictions
+🐛 Fix message ordering on the public timeline
+♻️ Extract origin handling into a helper
+✅ Cover the upload handler
+⬆️ Upgrade dependencies
+```
+
+### Pull requests
+
+PR titles follow the same Gitmoji convention as commits.
+
+Every PR must be labeled. `release-drafter` (`.github/release-drafter.yml`) uses the label to
+choose both the changelog category and the version bump:
+
+| Label                   | Category       | Version bump |
+| ----------------------- | -------------- | ------------ |
+| `feature`               | 🚀 Features    | major        |
+| `enhancement`           | 🚀 Features    | minor        |
+| `fix`, `bugfix`, `bug`  | 🐛 Bug Fixes   | patch        |
+| `chore`, `dependencies` | 🧹 Maintenance | patch        |
+
+An unlabeled PR falls back to a patch bump. A release draft is kept up to date on every push to
+`main`; drafts that are a pure patch bump are published automatically on the first of each month.
 
 ## CI/CD
 
-GitHub Actions workflows: `integration.yml` (test + build + SonarCloud), `quality.yaml`
-(Prettier + ESLint), `release.yaml` (build artifact + Docker multi-arch push).
-Docker: multi-stage build (node:22-alpine → nginx:stable-alpine).
+GitHub Actions workflows: `integration.yml` (test + build + SonarCloud + Dependabot
+automerge), `quality.yaml` (Prettier + ESLint), `release-drafter.yml` (maintains the draft
+release), `release-monthly.yml` (publishes a patch draft monthly), `release.yml` (build
+artifact + Docker multi-arch push to `systemli/ticker-admin`).
+Docker: multi-stage build (node:24-alpine → nginx:stable-alpine). The image bakes
+`docker/nginx.conf`, which serves the SPA only; the `/api/` proxy lives in
+`docker/nginx.conf.template` and is mounted at runtime.
+
+Deployment, configuration and troubleshooting are documented centrally at
+<https://systemli.github.io/ticker/>.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,32 +1,73 @@
 # ticker-admin
 
-[![Integration](https://github.com/systemli/ticker-admin/actions/workflows/integration.yml/badge.svg)](https://github.com/systemli/ticker-admin/actions/workflows/integration.yml) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=systemli_ticker-admin&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=systemli_ticker-admin) [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=systemli_ticker-admin&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=systemli_ticker-admin) [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=systemli_ticker-admin&metric=coverage)](https://sonarcloud.io/summary/new_code?id=systemli_ticker-admin)
+[![Integration](https://github.com/systemli/ticker-admin/actions/workflows/integration.yml/badge.svg)](https://github.com/systemli/ticker-admin/actions/workflows/integration.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=systemli_ticker-admin&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=systemli_ticker-admin)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=systemli_ticker-admin&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=systemli_ticker-admin)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=systemli_ticker-admin&metric=coverage)](https://sonarcloud.io/summary/new_code?id=systemli_ticker-admin)
+
+The admin interface for the [Ticker project](https://github.com/systemli/ticker). Editors use it to
+manage tickers, post messages, connect integrations and administer users.
+
+It is a static single-page application and holds no data of its own; everything lives in the
+[ticker](https://github.com/systemli/ticker) API.
+
+## Documentation
+
+**<https://systemli.github.io/ticker/>**
+
+Installation, configuration, deployment and troubleshooting for the whole stack are documented
+centrally:
+
+- [Installation](https://systemli.github.io/ticker/installation/) — running the full stack with Docker
+- [Configuration](https://systemli.github.io/ticker/configuration/)
+- [Troubleshooting](https://systemli.github.io/ticker/troubleshooting/)
+
+The published image is [`systemli/ticker-admin`](https://hub.docker.com/r/systemli/ticker-admin).
 
 ## Development
 
-**Requirement:** Running instance of [ticker](https://github.com/systemli/ticker), default: <http://localhost:8080/v1>
+**Requirements:** Node 24 (see `.nvmrc`) and a running [ticker](https://github.com/systemli/ticker)
+API.
 
 ```shell
-# Install dependencies
-yarn install
-
-# Start development server (http://localhost:3000)
-yarn run dev
+nvm use
+npm install
+npm run dev        # http://localhost:3000
 ```
 
-## Configuration
-
-Place configuration in `.env` file and restart/rebuild the ticker-admin
+Point it at your API with a `.env` file. The URL must include the `/v1` suffix:
 
 ```shell
 TICKER_API_URL=http://localhost:8080/v1
 ```
 
+Without this the application falls back to a relative `/api`, which only works when something is
+proxying that path — as the Docker image expects. Restart the dev server after changing `.env`.
+
+### Commands
+
+```shell
+npm test           # vitest, watch mode
+npm run coverage
+npm run lint
+npm run tsc        # type check
+npm run build
+npm run preview
+```
+
+See [AGENTS.md](AGENTS.md) for project structure, conventions and testing patterns, and the
+[development guide](https://systemli.github.io/ticker/development/) for working across the three
+repositories.
+
 ## Localization
 
-Strings are localized on the [locales](./src/i18n/locales) folder. To add more languages, please update those files:
+Strings live in the [locales](./src/i18n/locales) folder. To add a language, update:
 
-- [i18n.ts](./src/i18n/i18n.ts) to localize all strings
-- [UserListItem.tsx](./src/components/user/UserListItem.tsx) to localize `dayjs` relative times
+- [i18n.ts](./src/i18n/i18n.ts) to register it
+- [UserListItem.tsx](./src/components/user/UserListItem.tsx) for `dayjs` relative times
 
-To add a new string, please use the `t('stringKey')` notation and update all the locales.
+Use the `t('stringKey')` notation for new strings and update all locales.
+
+## Licence
+
+GPL-3.0. See [LICENSE](LICENSE).

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -1,15 +1,42 @@
+# Rendered to /etc/nginx/conf.d/default.conf at container start, with
+# ${TICKER_API_URL} substituted from the environment.
+#
+# TICKER_API_URL must include the /v1 suffix, for example
+# http://ticker:8080/v1 -- the application requests paths below /api/, which
+# this proxy maps onto the API's /v1 routes.
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 server {
     listen 80;
     root /usr/share/nginx/html;
     index index.html;
 
+    # The API accepts uploads up to 10 MB; nginx would otherwise cap them at 1 MB.
+    client_max_body_size 10m;
+
     location /api/ {
         proxy_pass ${TICKER_API_URL}/;
         proxy_ssl_server_name on;
+        # The API resolves which ticker a request belongs to from Origin, and
+        # browsers omit it on same-origin GET requests, so set it explicitly.
         proxy_set_header Origin $scheme://$http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Realtime updates connect to /api/ws and need an HTTP/1.1 upgrade.
+        # The server pings every 54s, so the read timeout must exceed that
+        # comfortably or connections are dropped repeatedly.
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_buffering off;
     }
 
     location / {


### PR DESCRIPTION
## Summary

Reduces the README to a pointer at the central documentation site, fixes two defects in the nginx
proxy template, and aligns the agent instructions with the other Ticker repositories.

## Why

Documentation for the three Ticker repositories is being consolidated into
[systemli/ticker](https://github.com/systemli/ticker), published at
<https://systemli.github.io/ticker/>. Installation, configuration, deployment and troubleshooting
concern the stack as a whole and were previously documented nowhere for this repository — the README
had no Docker or deployment section at all, despite an image being published.

The README also carried instructions that no longer matched the repository:

- it asked for `yarn install` and `yarn run dev`, although there is no `yarn.lock`,
  `packageManager` pins npm and every workflow uses `npm ci`;
- it stated no Node version, while `.nvmrc` and `engines` pin 24;
- it did not mention that `TICKER_API_URL` must include the `/v1` suffix, nor that the value is
  build-time only and the Docker image relies on a runtime proxy instead;
- it had no licence section, unlike the sibling repositories.

## Proxy fixes

`docker/nginx.conf.template` had two defects. Both affect anyone using this repository's own
`docker-compose.yml`, which mounts the template.

- **WebSocket connections could not upgrade.** The `/api/` block set neither
  `proxy_http_version 1.1` nor the `Upgrade` and `Connection` headers.
- **Uploads over 1 MB were rejected by the proxy.** It inherited nginx's default
  `client_max_body_size` while the API itself accepts 10 MB.

The read timeout is also raised. The default of 60 seconds sits only 6 seconds above the server's
ping period, which is enough to drop idle connections.

## Also included

A `.dockerignore`, which the repository lacked — the build context previously included
`node_modules`, `dist`, `coverage` and any local `.env`, so a local build could bake a developer's
API URL into the image.

`CLAUDE.md` is added as a symlink to `AGENTS.md`, and `AGENTS.md` adopts the commit and pull request
conventions now shared across the three repositories. Its drifted references are corrected too:
`eslint.config.js` was named as `.eslintrc.cjs`, `release.yml` as `release.yaml`, two release
workflows were missing, and the pinned dependency versions had all moved on.

Companion pull request: systemli/ticker#470.
