### PR TITLE
✨ Serve attachments through /api and proxy it in the image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,10 @@ describe('ComponentName', () => {
 ## Environment Variables
 
 - Prefixed with `TICKER_` for Vite exposure (configured in `vite.config.ts`)
-- `TICKER_API_URL` — backend API base URL (see `.env` and `.env.test`)
+- `TICKER_API_URL` — backend API base URL, including the `/v1` suffix. Normally unset: the app then
+  uses a relative `/api`, which the dev-server proxy and the image's nginx both forward. Attachment
+  URLs come back relative as `/api/media/<file>`; resolve them with `mediaUrl()` from
+  `src/api/Api.ts` so they also work with an absolute value.
 
 ## Commits and Pull Requests
 
@@ -219,9 +222,9 @@ GitHub Actions workflows: `integration.yml` (test + build + SonarCloud + Dependa
 automerge), `quality.yaml` (Prettier + ESLint), `release-drafter.yml` (maintains the draft
 release), `release-monthly.yml` (publishes a patch draft monthly), `release.yml` (build
 artifact + Docker multi-arch push to `systemli/ticker-admin`).
-Docker: multi-stage build (node:24-alpine → nginx:stable-alpine). The image bakes
-`docker/nginx.conf`, which serves the SPA only; the `/api/` proxy lives in
-`docker/nginx.conf.template` and is mounted at runtime.
+Docker: multi-stage build (node:24-alpine → nginx:stable-alpine). The image ships
+`docker/nginx.conf.template` to `/etc/nginx/templates/`, which the base image renders at start with
+`TICKER_API_URL` substituted, so the container serves the SPA and proxies `/api/` itself.
 
 Deployment, configuration and troubleshooting are documented centrally at
 <https://systemli.github.io/ticker/>.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,12 @@ RUN npm run build
 FROM nginx:stable-alpine3.23
 
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+# Rendered by the base image's envsubst at container start, so TICKER_API_URL is
+# a runtime setting rather than a mount. The default only keeps nginx starting --
+# it resolves an unset variable and an unresolvable upstream is a fatal error, so
+# without it the container would exit instead of serving the app. Override it with
+# the address of your API.
+ENV TICKER_API_URL=http://127.0.0.1:8080/v1
+COPY docker/nginx.conf.template /etc/nginx/templates/default.conf.template
 
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -35,14 +35,13 @@ npm install
 npm run dev        # http://localhost:3000
 ```
 
-Point it at your API with a `.env` file. The URL must include the `/v1` suffix:
+The dev server proxies `/api` to `http://localhost:8080/v1`, so run the API alongside it and nothing
+needs configuring.
 
-```shell
-TICKER_API_URL=http://localhost:8080/v1
-```
-
-Without this the application falls back to a relative `/api`, which only works when something is
-proxying that path — as the Docker image expects. Restart the dev server after changing `.env`.
+> **Delete a leftover `.env`.** `TICKER_API_URL` overrides the proxy with an absolute address.
+> Requests still work, but attachment images do not: their URLs are relative and would resolve
+> against the dev server instead of the API. The file is gitignored, so an old one may still be in
+> your checkout.
 
 ### Commands
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     build: .
     ports:
       - '8080:80'
-    volumes:
-      - ./docker/nginx.conf.template:/etc/nginx/templates/default.conf.template:ro
-    env_file:
-      - .env
+    environment:
+      # Must include the /v1 suffix.
+      TICKER_API_URL: ${TICKER_API_URL:-http://host.docker.internal:8080/v1}

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,9 +1,0 @@
-server {
-    listen 80;
-    root /usr/share/nginx/html;
-    index index.html;
-
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-}

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -3,7 +3,13 @@
 #
 # TICKER_API_URL must include the /v1 suffix, for example
 # http://ticker:8080/v1 -- the application requests paths below /api/, which
-# this proxy maps onto the API's /v1 routes.
+# this proxy maps onto the API's /v1 routes. Attachments are among them, at
+# /api/media/<file>.
+#
+# It has to be set: nginx refuses to start with an empty or unresolvable
+# proxy_pass. Note the same name is a build-time variable for the application
+# bundle; the published image is built without it, so the value here configures
+# this proxy only.
 
 map $http_upgrade $connection_upgrade {
     default upgrade;
@@ -17,6 +23,16 @@ server {
 
     # The API accepts uploads up to 10 MB; nginx would otherwise cap them at 1 MB.
     client_max_body_size 10m;
+
+    # Attachments. Buffered and cacheable, unlike the rest of /api/, and they
+    # need no Origin because the API resolves them by UUID.
+    location /api/media/ {
+        proxy_pass ${TICKER_API_URL}/media/;
+        proxy_ssl_server_name on;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 
     location /api/ {
         proxy_pass ${TICKER_API_URL}/;

--- a/src/api/Api.test.ts
+++ b/src/api/Api.test.ts
@@ -1,4 +1,15 @@
-import { apiClient, apiHeaders, ApiResponse, handleApiCall } from './Api'
+import { apiClient, apiHeaders, ApiResponse, handleApiCall, mediaUrl } from './Api'
+
+describe('mediaUrl', () => {
+  it('passes through relative attachment URLs', () => {
+    // ApiUrl is the relative default in tests.
+    expect(mediaUrl('/api/media/uuid.jpg')).toEqual('/api/media/uuid.jpg')
+  })
+
+  it('leaves anything else alone', () => {
+    expect(mediaUrl('https://cdn.example.org/media/uuid.jpg')).toEqual('https://cdn.example.org/media/uuid.jpg')
+  })
+})
 
 describe('apiClient', () => {
   beforeEach(() => {

--- a/src/api/Api.ts
+++ b/src/api/Api.ts
@@ -1,5 +1,12 @@
 export const ApiUrl = import.meta.env.TICKER_API_URL || '/api'
 
+// The API returns attachment URLs relative to the site serving them, as
+// /api/media/<file>. That resolves by itself with the default relative ApiUrl,
+// but not when TICKER_API_URL points somewhere else.
+export function mediaUrl(url: string): string {
+  return url.startsWith('/api/') ? `${ApiUrl}${url.slice('/api'.length)}` : url
+}
+
 type StatusSuccess = 'success'
 type StatusError = 'error'
 type Status = StatusSuccess | StatusError

--- a/src/components/message/AttachmentPreview.tsx
+++ b/src/components/message/AttachmentPreview.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { IconButton, ImageListItem } from '@mui/material'
+import { mediaUrl } from '../../api/Api'
 import { Upload } from '../../api/Upload'
 import { faXmarkSquare } from '@fortawesome/free-solid-svg-icons'
 
@@ -21,7 +22,7 @@ const AttachmentPreview: FC<Props> = ({ onDelete, upload }) => {
     <ImageListItem sx={{ position: 'relative' }}>
       <img
         alt=""
-        src={upload.url}
+        src={mediaUrl(upload.url)}
         style={{
           objectFit: 'cover',
         }}

--- a/src/components/message/MessageAttachments.tsx
+++ b/src/components/message/MessageAttachments.tsx
@@ -1,5 +1,6 @@
 import { ImageList, ImageListItem } from '@mui/material'
 import { FC, useState } from 'react'
+import { mediaUrl } from '../../api/Api'
 import { Message } from '../../api/Message'
 import Lightbox from '../common/Lightbox'
 
@@ -38,11 +39,11 @@ const MessageAttachements: FC<Props> = ({ message }) => {
               }
             }}
           >
-            <img src={image.url} alt={image.url} />
+            <img src={mediaUrl(image.url)} alt={image.url} />
           </ImageListItem>
         ))}
       </ImageList>
-      <Lightbox images={attachments.map(image => image.url)} initialImage={currentImage} open={open} onClose={() => setOpen(false)} />
+      <Lightbox images={attachments.map(image => mediaUrl(image.url))} initialImage={currentImage} open={open} onClose={() => setOpen(false)} />
     </>
   )
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,17 @@ export default defineConfig({
   envPrefix: 'TICKER_',
   server: {
     port: 3000,
+    // Mirrors production: the app requests /api and the proxy maps it onto the
+    // API's /v1 routes. Origin has to be set explicitly, because a same-origin
+    // GET does not send one and the API resolves the ticker from it.
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        rewrite: path => path.replace(/^\/api/, '/v1'),
+        ws: true,
+        headers: { Origin: 'http://localhost:3000' },
+      },
+    },
   },
   plugins: [react()],
   test: {


### PR DESCRIPTION
## Goal

Companion to systemli/ticker#472, which stops the API from needing a public hostname of its own. Attachment URLs it returns are now relative, `/api/media/<file>`, so they are served by whichever site the page came from.

## What changes

**Resolve attachment URLs against the API base.** With the default relative `ApiUrl` the URL passes through untouched. With an absolute `TICKER_API_URL`, fetches would go to the API while images resolved against the app's own origin, which serves no `/api`. `mediaUrl()` closes that gap in one line and is a no-op in every shipped configuration. It is applied to message attachments, the upload preview and the lightbox.

**Ship the nginx proxy template in the image.** The image baked `docker/nginx.conf`, which serves the SPA and nothing else; the `/api` proxy sat in a template that only took effect if someone mounted it at runtime. Without a proxy in front the published image had no API — and, now that attachment URLs are relative, no images either. The template is copied to `/etc/nginx/templates/` instead and rendered by the base image at start, making `TICKER_API_URL` a runtime setting. It carries a default, because nginx treats both an unset variable and an unresolvable upstream as fatal and the container would otherwise exit instead of serving the app. Attachments get their own `location`, buffered and cacheable, unlike the websocket the shared `/api/` block is tuned for.

**Proxy `/api` from the dev server.** Development pointed the app at an absolute API URL, which no longer works for attachments. The Vite server now proxies `/api` the way production does.

## Note for developers

`.env` is gitignored, so an existing checkout may still contain an absolute `TICKER_API_URL`. It overrides the proxy and breaks attachment images while everything else keeps working — delete it. The README says so as well.