### PR TITLE
🐛 Repair the UI regressions from the MUI 9 upgrade

### DIFF
--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -6,7 +6,7 @@ const Loader: FC = () => {
   const { t } = useTranslation()
 
   return (
-    <Stack alignItems="center" justifyContent="center" sx={{ m: 10 }}>
+    <Stack sx={{ alignItems: 'center', justifyContent: 'center', m: 10 }}>
       <CircularProgress size="3rem" />
       <Typography component="span" sx={{ pt: 2 }} variant="h5">
         {t('common.loading')}

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import { Container, Typography } from '@mui/material'
-import { FC } from 'react'
+import { FC, ReactElement } from 'react'
 import { Navigate, RouteProps } from 'react-router'
 import { useTranslation } from 'react-i18next'
 import { Roles } from '../contexts/AuthContext'
@@ -7,7 +7,7 @@ import useAuth from '../contexts/useAuth'
 
 type Props = RouteProps & {
   role: Roles
-  outlet: JSX.Element
+  outlet: ReactElement
 }
 
 const ProtectedRoute: FC<Props> = ({ role, outlet }) => {

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -36,7 +36,7 @@ const Modal: FC<Props> = ({
   return (
     <Dialog fullWidth={fullWidth} maxWidth={maxWidth} open={open}>
       <DialogTitle>
-        <Stack alignItems="center" direction="row" justifyContent="space-between">
+        <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between' }}>
           {title}
           <IconButton aria-label={t('action.close')} onClick={onClose}>
             <Close />

--- a/src/components/message/MessageFooter.tsx
+++ b/src/components/message/MessageFooter.tsx
@@ -23,12 +23,12 @@ const formatDate = (dateString: string): string => {
 
 const MessageFooter: FC<Props> = ({ message }) => {
   return (
-    <Stack alignItems="center" direction="row" justifyContent="space-between" sx={{ mt: 2, pr: 2.5 }}>
-      <Stack alignItems="center" direction="row" spacing={0.5}>
+    <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between', mt: 2, pr: 2.5 }}>
+      <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
         <FontAwesomeIcon aria-hidden="true" icon={faClock} size="2xs" color={colors.grey[600]} />
         <Typography variant="caption">{formatDate(message.createdAt)}</Typography>
       </Stack>
-      <Stack alignItems="center" direction="row" spacing="0.5">
+      <Stack direction="row" spacing="0.5" sx={{ alignItems: 'center' }}>
         <Icon icon={faTelegram} url={message.telegramUrl} label="Telegram" />
         <Icon icon={faMastodon} url={message.mastodonUrl} label="Mastodon" />
         <Icon icon={faBluesky} url={message.blueskyUrl} label="Bluesky" />

--- a/src/components/message/MessageForm.tsx
+++ b/src/components/message/MessageForm.tsx
@@ -133,8 +133,8 @@ const MessageForm: FC<Props> = ({ ticker }) => {
             disabled={!ticker.active}
           />
         </FormGroup>
-        <Stack alignItems="center" direction="row" justifyContent="space-between">
-          <Box display="flex">
+        <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between' }}>
+          <Box sx={{ display: 'flex' }}>
             <Button disabled={disabled} startIcon={<FontAwesomeIcon icon={faPaperPlane} />} sx={{ mr: 1 }} type="submit" variant="outlined">
               {t('action.send')}
             </Button>

--- a/src/components/settings/InactiveSettingsCard.tsx
+++ b/src/components/settings/InactiveSettingsCard.tsx
@@ -37,7 +37,7 @@ const InactiveSettingsCard: FC = () => {
   return (
     <Card>
       <CardContent>
-        <Stack alignItems="center" direction="row" justifyContent="space-between">
+        <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography component="h3" variant="h5">
             {t('title.inactive')}
           </Typography>
@@ -45,26 +45,26 @@ const InactiveSettingsCard: FC = () => {
             {t('action.edit')}
           </Button>
         </Stack>
-        <Typography color="GrayText" component="span" variant="body2">
+        <Typography component="span" variant="body2" sx={{ color: 'GrayText' }}>
           {t('status.description')}
         </Typography>
       </CardContent>
       <Divider variant="middle" />
       <CardContent>
         <Box sx={{ mb: 1 }}>
-          <Typography color="GrayText" component="span" variant="body2">
+          <Typography component="span" variant="body2" sx={{ color: 'GrayText' }}>
             {t('common.headline')}
           </Typography>
           <Typography>{setting.value.headline}</Typography>
         </Box>
         <Box sx={{ mb: 1 }}>
-          <Typography color="GrayText" component="span" variant="body2">
+          <Typography component="span" variant="body2" sx={{ color: 'GrayText' }}>
             {t('common.subheadline')}
           </Typography>
           <Typography>{setting.value.subHeadline}</Typography>
         </Box>
         <Box sx={{ mb: 1 }}>
-          <Typography color="GrayText" component="span" variant="body2">
+          <Typography component="span" variant="body2" sx={{ color: 'GrayText' }}>
             {t('common.description')}
           </Typography>
           <Typography>{setting.value.description}</Typography>
@@ -72,7 +72,7 @@ const InactiveSettingsCard: FC = () => {
         <Grid container>
           <Grid size={{ lg: 6, xs: 12 }}>
             <Box sx={{ mb: 1 }}>
-              <Typography color="GrayText" component="span" variant="body2">
+              <Typography component="span" variant="body2" sx={{ color: 'GrayText' }}>
                 {t('common.author')}
               </Typography>
               <Typography>{setting.value.author}</Typography>
@@ -80,7 +80,7 @@ const InactiveSettingsCard: FC = () => {
           </Grid>
           <Grid size={{ lg: 6, xs: 12 }}>
             <Box sx={{ mb: 1 }}>
-              <Typography color="GrayText" component="span" variant="body2">
+              <Typography component="span" variant="body2" sx={{ color: 'GrayText' }}>
                 {t('integrations.homepage')}
               </Typography>
               <Typography>{setting.value.homepage}</Typography>
@@ -88,7 +88,7 @@ const InactiveSettingsCard: FC = () => {
           </Grid>
           <Grid size={{ lg: 6, xs: 12 }}>
             <Box sx={{ mb: 1 }}>
-              <Typography color="GrayText" component="span" variant="body2">
+              <Typography component="span" variant="body2" sx={{ color: 'GrayText' }}>
                 {t('user.email')}
               </Typography>
               <Typography>{setting.value.email}</Typography>
@@ -96,7 +96,7 @@ const InactiveSettingsCard: FC = () => {
           </Grid>
           <Grid size={{ lg: 6, xs: 12 }}>
             <Box sx={{ mb: 1 }}>
-              <Typography color="GrayText" component="span" variant="body2">
+              <Typography component="span" variant="body2" sx={{ color: 'GrayText' }}>
                 {t('social.twitter')}
               </Typography>
               <Typography>{setting.value.twitter}</Typography>

--- a/src/components/settings/SettingsCard.tsx
+++ b/src/components/settings/SettingsCard.tsx
@@ -36,7 +36,7 @@ function SettingsCard<T>({ title, description, editTestId, queryKey, errorMessag
   return (
     <Card>
       <CardContent>
-        <Stack alignItems="center" direction="row" justifyContent="space-between">
+        <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography component="h3" variant="h5">
             {t(title)}
           </Typography>
@@ -44,7 +44,7 @@ function SettingsCard<T>({ title, description, editTestId, queryKey, errorMessag
             {t('action.edit')}
           </Button>
         </Stack>
-        <Typography color="GrayText" component="span" variant="body2">
+        <Typography component="span" variant="body2" sx={{ color: 'GrayText' }}>
           {t(description)}
         </Typography>
       </CardContent>

--- a/src/components/settings/SignalGroupSettingsCard.tsx
+++ b/src/components/settings/SignalGroupSettingsCard.tsx
@@ -24,19 +24,19 @@ const SignalGroupSettingsCard: FC<{ onSaved?: () => void }> = ({ onSaved }) => {
       {({ data, formOpen, onFormClose }) => (
         <>
           <Box sx={{ mb: 1 }}>
-            <Typography color="GrayText" component="span" variant="body2">
+            <Typography component="span" variant="body2" sx={{ color: 'GrayText' }}>
               {t('settings.signalGroup.apiUrl')}
             </Typography>
             <Typography>{data.setting.value.apiUrl || '—'}</Typography>
           </Box>
           <Box sx={{ mb: 1 }}>
-            <Typography color="GrayText" component="span" variant="body2">
+            <Typography component="span" variant="body2" sx={{ color: 'GrayText' }}>
               {t('settings.signalGroup.account')}
             </Typography>
             <Typography>{data.setting.value.account || '—'}</Typography>
           </Box>
           <Box sx={{ mb: 1 }}>
-            <Typography color="GrayText" component="span" variant="body2">
+            <Typography component="span" variant="body2" sx={{ color: 'GrayText' }}>
               {t('settings.signalGroup.avatar')}
             </Typography>
             <Typography>{data.setting.value.avatar || '—'}</Typography>

--- a/src/components/settings/TelegramSettingsCard.tsx
+++ b/src/components/settings/TelegramSettingsCard.tsx
@@ -24,13 +24,13 @@ const TelegramSettingsCard: FC<{ onSaved?: () => void }> = ({ onSaved }) => {
       {({ data, formOpen, onFormClose }) => (
         <>
           <Box sx={{ mb: 1 }}>
-            <Typography color="GrayText" component="span" variant="body2">
+            <Typography component="span" variant="body2" sx={{ color: 'GrayText' }}>
               {t('settings.telegram.botUsername')}
             </Typography>
             <Typography>{data.setting.value.botUsername || '—'}</Typography>
           </Box>
           <Box sx={{ mb: 1 }}>
-            <Typography color="GrayText" component="span" variant="body2">
+            <Typography component="span" variant="body2" sx={{ color: 'GrayText' }}>
               {t('settings.telegram.token')}
             </Typography>
             <Typography>{data.setting.value.token || '—'}</Typography>

--- a/src/components/ticker/BlueskyCard.tsx
+++ b/src/components/ticker/BlueskyCard.tsx
@@ -47,10 +47,10 @@ const BlueskyCard: FC<Props> = ({ ticker }) => {
   const details = bluesky.connected ? (
     <Stack spacing={1}>
       <div>
-        <Typography variant="caption" color="text.secondary">
+        <Typography variant="caption" color="textSecondary">
           {t('integrations.profile')}
         </Typography>
-        <Stack direction="row" alignItems="center" spacing={1}>
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
           <Link href={profileUrl} rel="noreferrer" target="_blank" variant="body2">
             {bluesky.handle}
           </Link>
@@ -58,7 +58,7 @@ const BlueskyCard: FC<Props> = ({ ticker }) => {
         </Stack>
       </div>
       <div>
-        <Typography variant="caption" color="text.secondary">
+        <Typography variant="caption" color="textSecondary">
           {t('integrations.bluesky.replyRestriction')}
         </Typography>
         <Typography variant="body2">{replyRestrictionLabel(bluesky.replyRestriction)}</Typography>

--- a/src/components/ticker/IntegrationCard.tsx
+++ b/src/components/ticker/IntegrationCard.tsx
@@ -83,13 +83,13 @@ const IntegrationCard: FC<IntegrationCardProps> = ({
     <>
       <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
         <CardContent>
-          <Stack alignItems="center" direction="row" justifyContent="space-between" spacing={1}>
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'center', justifyContent: 'space-between' }}>
             <Typography component="h5" variant="h5">
               <FontAwesomeIcon aria-hidden="true" icon={icon} /> {title}
             </Typography>
             <Chip label={t(`integrations.integrationStatus.${status}`)} color={color} size="small" variant="outlined" />
           </Stack>
-          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+          <Typography variant="body2" color="textSecondary" sx={{ mt: 1 }}>
             {description}
           </Typography>
         </CardContent>

--- a/src/components/ticker/LocationSearch.tsx
+++ b/src/components/ticker/LocationSearch.tsx
@@ -28,7 +28,7 @@ interface Props {
 const LocationSearch: FC<Props> = ({ callback }) => {
   const { t } = useTranslation()
   const [options, setOptions] = useState<SearchResult[]>([])
-  const previousController = useRef<AbortController>()
+  const previousController = useRef<AbortController | null>(null)
 
   const handleInputChange = (_: React.SyntheticEvent, value: string) => {
     if (previousController.current) {

--- a/src/components/ticker/MastodonCard.tsx
+++ b/src/components/ticker/MastodonCard.tsx
@@ -33,10 +33,10 @@ const MastodonCard: FC<Props> = ({ ticker }) => {
   const details = mastodon.connected ? (
     <Stack spacing={1}>
       <div>
-        <Typography variant="caption" color="text.secondary">
+        <Typography variant="caption" color="textSecondary">
           {t('integrations.profile')}
         </Typography>
-        <Stack direction="row" alignItems="center" spacing={1}>
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
           <Link href={profileUrl} rel="noreferrer" target="_blank" variant="body2">
             {profileHandle}
           </Link>

--- a/src/components/ticker/SignalGroupAdminForm.tsx
+++ b/src/components/ticker/SignalGroupAdminForm.tsx
@@ -63,12 +63,14 @@ const SignalGroupAdminForm: FC<Props> = ({ callback, ticker, setSubmitting }) =>
               required
               helperText={errors.number ? errors.number?.message : null}
               error={errors.number ? true : false}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <FontAwesomeIcon icon={faPhone} />
-                  </InputAdornment>
-                ),
+              slotProps={{
+                input: {
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <FontAwesomeIcon icon={faPhone} />
+                    </InputAdornment>
+                  ),
+                },
               }}
             />
           </FormGroup>

--- a/src/components/ticker/SignalGroupCard.tsx
+++ b/src/components/ticker/SignalGroupCard.tsx
@@ -91,10 +91,10 @@ const SignalGroupCard: FC<Props> = ({ ticker }) => {
   const details = signalGroup.connected ? (
     <Stack spacing={1}>
       <div>
-        <Typography variant="caption" color="text.secondary">
+        <Typography variant="caption" color="textSecondary">
           {t('integrations.signal.inviteLink')}
         </Typography>
-        <Stack direction="row" alignItems="center" spacing={1}>
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
           <Link href={signalGroup.groupInviteLink} rel="noreferrer" target="_blank" variant="body2">
             {ticker.title}
           </Link>

--- a/src/components/ticker/TelegramCard.tsx
+++ b/src/components/ticker/TelegramCard.tsx
@@ -34,10 +34,10 @@ const TelegramCard: FC<Props> = ({ ticker }) => {
   const details = telegram.connected ? (
     <Stack spacing={1}>
       <div>
-        <Typography variant="caption" color="text.secondary">
+        <Typography variant="caption" color="textSecondary">
           {t('integrations.telegram.channel')}
         </Typography>
-        <Stack direction="row" alignItems="center" spacing={1}>
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
           <Link href={channelUrl} rel="noreferrer" target="_blank" variant="body2">
             {telegram.channelName}
           </Link>
@@ -45,10 +45,10 @@ const TelegramCard: FC<Props> = ({ ticker }) => {
         </Stack>
       </div>
       <div>
-        <Typography variant="caption" color="text.secondary">
+        <Typography variant="caption" color="textSecondary">
           {t('integrations.telegram.botLabel')}
         </Typography>
-        <Stack direction="row" alignItems="center" spacing={0.5}>
+        <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
           <Typography variant="body2">{telegram.botUsername}</Typography>
           <Tooltip title={t('integrations.telegram.botHint')}>
             <FontAwesomeIcon icon={faCircleInfo} size="sm" style={{ color: 'gray', cursor: 'help' }} />

--- a/src/components/ticker/Ticker.tsx
+++ b/src/components/ticker/Ticker.tsx
@@ -25,7 +25,7 @@ const Ticker: FC<Props> = ({ ticker, isLoading }) => {
   const [formModalOpen, setFormModalOpen] = useState<boolean>(false)
 
   const headline = () => (
-    <Stack alignItems="center" direction="row" justifyContent="space-between" mb={2}>
+    <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
       <Typography component="h2" gutterBottom variant="h3">
         {t('title.ticker')}
       </Typography>
@@ -67,7 +67,7 @@ const Ticker: FC<Props> = ({ ticker, isLoading }) => {
           <Alert severity="warning">{t('tickers.disabled')}</Alert>
         </Grid>
       ) : null}
-      <Grid display={{ xs: 'none', md: 'block' }} size={{ md: 4, xs: 12 }}>
+      <Grid size={{ md: 4, xs: 12 }} sx={{ display: { xs: 'none', md: 'block' } }}>
         <TickerCard ticker={ticker} />
         {user?.roles.includes('admin') ? (
           <>

--- a/src/components/ticker/TickerCard.tsx
+++ b/src/components/ticker/TickerCard.tsx
@@ -24,9 +24,9 @@ const TickerCard: FC<Props> = ({ ticker }) => {
   return (
     <Card>
       <CardContent>
-        <Stack direction="row" spacing={1} alignItems="center">
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
           <FontAwesomeIcon aria-hidden="true" icon={faCircleInfo} />
-          <Typography component="h5" variant="h5" flexGrow={1}>
+          <Typography component="h5" variant="h5" sx={{ flexGrow: 1 }}>
             {t('common.info')}
           </Typography>
         </Stack>
@@ -36,7 +36,7 @@ const TickerCard: FC<Props> = ({ ticker }) => {
         </Stack>
         <Chip icon={icon} label={status} variant="outlined" sx={{ mt: 2 }} size="small" color={color} />
         <Divider sx={{ mt: 2 }} />
-        <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 2 }}>
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'center', mt: 2 }}>
           <Campaign />
           <Typography component="h6" variant="h6">
             {t('title.integrations')}
@@ -57,9 +57,9 @@ const Integrations = ({ ticker }: { ticker: Ticker }) => {
         <TickerProperty
           label="Websites"
           value={ticker.websites.map(website => (
-            <Stack key={website.origin} direction="row" alignItems="center" spacing={0.5}>
+            <Stack key={website.origin} direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
               <FontAwesomeIcon aria-hidden="true" icon={faGlobeEurope} color={grey[800]} />
-              <Typography variant="body2" flexGrow={1}>
+              <Typography variant="body2" sx={{ flexGrow: 1 }}>
                 <Link href={website.origin} target="_blank" rel="noopener noreferrer">
                   {website.origin.replace(/(^\w+:|^)\/\//, '')}
                 </Link>
@@ -122,13 +122,13 @@ const IntegrationChip = ({ active, title, link }: { active: boolean; title: stri
   const { t } = useTranslation()
 
   return (
-    <Stack direction="row" alignItems="center" spacing={0.5}>
+    <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
       <Tooltip title={t(active ? 'status.active' : 'status.inactive')} arrow placement="top">
         <span>
           <FontAwesomeIcon aria-hidden="true" icon={active ? faToggleOn : faToggleOff} color={grey[800]} />
         </span>
       </Tooltip>
-      <Typography variant="body2" flexGrow={1}>
+      <Typography variant="body2" sx={{ flexGrow: 1 }}>
         <Link href={link} target="_blank" rel="noopener noreferrer">
           {title}
         </Link>

--- a/src/components/ticker/TickerListFilter.tsx
+++ b/src/components/ticker/TickerListFilter.tsx
@@ -16,7 +16,7 @@ const TickerListFilter: FC<Props> = ({ params, onTitleChange, onOriginChange, on
   const { t } = useTranslation()
 
   return (
-    <Stack direction="row" alignItems="center">
+    <Stack direction="row" sx={{ alignItems: 'center' }}>
       <Box sx={{ px: 1 }}>
         <FontAwesomeIcon aria-hidden="true" icon={faFilter} />
       </Box>

--- a/src/components/ticker/TickerListItem.tsx
+++ b/src/components/ticker/TickerListItem.tsx
@@ -1,7 +1,7 @@
 import { faCheck, faHandPointer, faPencil, faTrash, faXmark } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { MoreVert } from '@mui/icons-material'
-import { colors, IconButton, MenuItem, Popover, TableCell, TableRow, Typography } from '@mui/material'
+import { colors, IconButton, MenuItem, MenuList, Popover, TableCell, TableRow, Typography } from '@mui/material'
 import React, { FC, memo, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { Ticker } from '../../api/Ticker'
@@ -51,13 +51,15 @@ const TickerListItem: FC<Props> = ({ ticker }: Props) => {
           <MoreVert />
         </IconButton>
         <Popover
-          PaperProps={{
-            sx: {
-              p: 1,
-              width: 140,
-              '& .MuiMenuItem-root': {
-                px: 1,
-                borderRadius: 0.75,
+          slotProps={{
+            paper: {
+              sx: {
+                p: 1,
+                width: 140,
+                '& .MuiMenuItem-root': {
+                  px: 1,
+                  borderRadius: 0.75,
+                },
               },
             },
           }}
@@ -67,38 +69,40 @@ const TickerListItem: FC<Props> = ({ ticker }: Props) => {
           open={Boolean(anchorEl)}
           transformOrigin={{ vertical: 'top', horizontal: 'right' }}
         >
-          <MenuItem
-            onClick={() => {
-              handleClose()
-              handleUse()
-            }}
-          >
-            <FontAwesomeIcon aria-hidden="true" icon={faHandPointer} />
-            <Typography sx={{ ml: 2 }}>{t('action.use')}</Typography>
-          </MenuItem>
-          <MenuItem
-            onClick={() => {
-              handleClose()
-              setFormModalOpen(true)
-            }}
-          >
-            <FontAwesomeIcon aria-hidden="true" icon={faPencil} />
-            <Typography sx={{ ml: 2 }}>{t('action.edit')}</Typography>
-          </MenuItem>
-          {user?.roles.includes('admin') ? (
-            <>
-              <MenuItem
-                onClick={() => {
-                  handleClose()
-                  setDeleteModalOpen(true)
-                }}
-                sx={{ color: colors.red[400] }}
-              >
-                <FontAwesomeIcon aria-hidden="true" icon={faTrash} />
-                <Typography sx={{ ml: 2 }}>{t('action.delete')}</Typography>
-              </MenuItem>
-            </>
-          ) : null}
+          <MenuList>
+            <MenuItem
+              onClick={() => {
+                handleClose()
+                handleUse()
+              }}
+            >
+              <FontAwesomeIcon aria-hidden="true" icon={faHandPointer} />
+              <Typography sx={{ ml: 2 }}>{t('action.use')}</Typography>
+            </MenuItem>
+            <MenuItem
+              onClick={() => {
+                handleClose()
+                setFormModalOpen(true)
+              }}
+            >
+              <FontAwesomeIcon aria-hidden="true" icon={faPencil} />
+              <Typography sx={{ ml: 2 }}>{t('action.edit')}</Typography>
+            </MenuItem>
+            {user?.roles.includes('admin') ? (
+              <>
+                <MenuItem
+                  onClick={() => {
+                    handleClose()
+                    setDeleteModalOpen(true)
+                  }}
+                  sx={{ color: colors.red[400] }}
+                >
+                  <FontAwesomeIcon aria-hidden="true" icon={faTrash} />
+                  <Typography sx={{ ml: 2 }}>{t('action.delete')}</Typography>
+                </MenuItem>
+              </>
+            ) : null}
+          </MenuList>
         </Popover>
         <TickerModalForm onClose={() => setFormModalOpen(false)} open={formModalOpen} ticker={ticker} />
         <TickerModalDelete onClose={() => setDeleteModalOpen(false)} open={deleteModalOpen} ticker={ticker} />

--- a/src/components/ticker/TickerListItems.tsx
+++ b/src/components/ticker/TickerListItems.tsx
@@ -20,7 +20,7 @@ const TickerListItems: FC<Props> = ({ token, params }) => {
       <TableBody>
         <TableRow>
           <TableCell colSpan={5}>
-            <Stack alignItems="center" justifyContent="center">
+            <Stack sx={{ alignItems: 'center', justifyContent: 'center' }}>
               <CircularProgress size="2rem" />
               <Typography component="span" sx={{ pt: 1 }}>
                 {t('common.loading')}
@@ -49,7 +49,7 @@ const TickerListItems: FC<Props> = ({ token, params }) => {
       <TableBody>
         <TableRow>
           <TableCell colSpan={5}>
-            <Stack alignItems="center" justifyContent="center">
+            <Stack sx={{ alignItems: 'center', justifyContent: 'center' }}>
               <Typography variant="body1">{t('tickers.error0Found')}</Typography>
             </Stack>
           </TableCell>

--- a/src/components/ticker/WebsiteCard.tsx
+++ b/src/components/ticker/WebsiteCard.tsx
@@ -27,7 +27,7 @@ const WebsiteCard: FC<Props> = ({ ticker }) => {
 
   const details = isConfigured ? (
     <Stack spacing={0.5}>
-      <Typography variant="caption" color="text.secondary">
+      <Typography variant="caption" color="textSecondary">
         {t('integrations.website.allowed')}
       </Typography>
       {websites.map(website => (

--- a/src/components/user/UserListItem.tsx
+++ b/src/components/user/UserListItem.tsx
@@ -50,13 +50,15 @@ const UserListItem: FC<Props> = ({ user }) => {
           <MoreVert />
         </IconButton>
         <Popover
-          PaperProps={{
-            sx: {
-              p: 1,
-              width: 140,
-              '& .MuiMenuItem-root': {
-                px: 1,
-                borderRadius: 0.75,
+          slotProps={{
+            paper: {
+              sx: {
+                p: 1,
+                width: 140,
+                '& .MuiMenuItem-root': {
+                  px: 1,
+                  borderRadius: 0.75,
+                },
               },
             },
           }}

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -20,7 +20,7 @@ const mockedLocalStorage = {
   length: 0,
   key: vi.fn(),
 }
-global.localStorage = mockedLocalStorage
+globalThis.localStorage = mockedLocalStorage
 
 beforeEach(() => {
   vi.clearAllMocks()

--- a/src/contexts/FeatureContext.tsx
+++ b/src/contexts/FeatureContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
+import { createContext, ReactElement, ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import { ApiResponse } from '../api/Api'
 import { Features, fetchFeaturesApi } from '../api/Features'
 import useAuth from './useAuth'
@@ -23,7 +23,7 @@ const initialFeatures: Features = {
   signalGroupEnabled: false,
 }
 
-export function FeatureProvider({ children }: Readonly<{ children: ReactNode }>): JSX.Element {
+export function FeatureProvider({ children }: Readonly<{ children: ReactNode }>): ReactElement {
   const { token } = useAuth()
   const [state, setState] = useState<FeatureState>({
     features: initialFeatures,

--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, createContext, useMemo, useState } from 'react'
+import { ReactElement, ReactNode, createContext, useMemo, useState } from 'react'
 
 type Severity = 'success' | 'error' | 'warning' | 'info'
 
@@ -16,7 +16,7 @@ interface NotificationContextType {
 
 const NotificationContext = createContext<NotificationContextType | undefined>(undefined)
 
-export function NotificationProvider({ children }: Readonly<{ children: ReactNode }>): JSX.Element {
+export function NotificationProvider({ children }: Readonly<{ children: ReactNode }>): ReactElement {
   const [notification, setNotification] = useState<Notification | undefined>(undefined)
   const [isOpen, setIsOpen] = useState<boolean>(false)
 

--- a/src/hooks/useDebounce.tsx
+++ b/src/hooks/useDebounce.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 
 function useDebounce<T>(value: T, delay: number, initialValue: T): T {
   const [debouncedValue, setDebouncedValue] = useState<T>(initialValue)
-  const timerRef = useRef<NodeJS.Timeout | null>()
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (timerRef.current) {

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -36,33 +36,50 @@ theme.components = {
         '&:hover': {
           boxShadow: 'none',
         },
+        variants: [
+          {
+            props: { variant: 'contained', color: 'inherit' },
+            style: {
+              color: palette.grey[800],
+              boxShadow: customShadows.z8,
+              '&:hover': {
+                backgroundColor: palette.grey[400],
+              },
+            },
+          },
+          {
+            props: { variant: 'contained', color: 'primary' },
+            style: {
+              boxShadow: customShadows.primary,
+            },
+          },
+          {
+            props: { variant: 'contained', color: 'secondary' },
+            style: {
+              boxShadow: customShadows.secondary,
+            },
+          },
+          {
+            props: { variant: 'outlined', color: 'inherit' },
+            style: {
+              border: `1px solid ${alpha(palette.grey[500], 0.32)}`,
+              '&:hover': {
+                backgroundColor: palette.action.hover,
+              },
+            },
+          },
+          {
+            props: { variant: 'text', color: 'inherit' },
+            style: {
+              '&:hover': {
+                backgroundColor: palette.action.hover,
+              },
+            },
+          },
+        ],
       },
       sizeLarge: {
         height: 48,
-      },
-      containedInherit: {
-        color: palette.grey[800],
-        boxShadow: customShadows.z8,
-        '&:hover': {
-          backgroundColor: palette.grey[400],
-        },
-      },
-      containedPrimary: {
-        boxShadow: customShadows.primary,
-      },
-      containedSecondary: {
-        boxShadow: customShadows.secondary,
-      },
-      outlinedInherit: {
-        border: `1px solid ${alpha(palette.grey[500], 0.32)}`,
-        '&:hover': {
-          backgroundColor: palette.action.hover,
-        },
-      },
-      textInherit: {
-        '&:hover': {
-          backgroundColor: palette.action.hover,
-        },
       },
     },
   },
@@ -78,8 +95,10 @@ theme.components = {
   },
   MuiCardHeader: {
     defaultProps: {
-      titleTypographyProps: { variant: 'h6' },
-      subheaderTypographyProps: { variant: 'body2' },
+      slotProps: {
+        title: { variant: 'h6' },
+        subheader: { variant: 'body2' },
+      },
     },
     styleOverrides: {
       root: {
@@ -193,9 +212,6 @@ theme.components = {
   },
   MuiTypography: {
     styleOverrides: {
-      paragraph: {
-        marginBottom: theme.spacing(1),
-      },
       gutterBottom: {
         marginBottom: theme.spacing(1),
       },

--- a/src/views/ErrorView.tsx
+++ b/src/views/ErrorView.tsx
@@ -23,7 +23,7 @@ const ErrorView: FC<Props> = ({ children, queryKey }) => {
           {t('error.ohNo')}
         </Typography>
         <Divider sx={{ mt: 1, mb: 2 }} />
-        <Stack alignItems="center" direction="row" spacing={2}>
+        <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
           <Box>
             <Button color="secondary" onClick={handleClick} variant="contained">
               {t('action.reload')}
@@ -33,7 +33,7 @@ const ErrorView: FC<Props> = ({ children, queryKey }) => {
             <Typography component="div" variant="body1">
               {children}
             </Typography>
-            <Typography color={colors.grey[700]} component="p" variant="body2">
+            <Typography component="p" variant="body2" sx={{ color: colors.grey[700] }}>
               {t('error.contactAdmin')}
             </Typography>
           </Box>

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -15,7 +15,7 @@ const SettingsView: FC = () => {
     <Layout>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12 }}>
-          <Stack alignItems="center" direction="row" justifyContent="space-between" mb={2}>
+          <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
             <Typography component="h2" gutterBottom variant="h3">
               {t('title.settings')}
             </Typography>

--- a/src/views/TickerListView.tsx
+++ b/src/views/TickerListView.tsx
@@ -17,7 +17,7 @@ const TickerListView: FC = () => {
     <Layout>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12 }}>
-          <Stack alignItems="center" direction="row" justifyContent="space-between" mb={2}>
+          <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
             <Typography component="h2" gutterBottom variant="h3">
               {t('title.tickers')}
             </Typography>

--- a/src/views/UsersView.tsx
+++ b/src/views/UsersView.tsx
@@ -15,7 +15,7 @@ const UsersView: FC = () => {
     <Layout>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12 }}>
-          <Stack alignItems="center" direction="row" justifyContent="space-between" mb={2}>
+          <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
             <Typography component="h2" gutterBottom variant="h3">
               {t('title.users')}
             </Typography>


### PR DESCRIPTION
## Summary

The MUI 9 upgrade (#891) broke the admin UI in several places without producing a single runtime error, most visibly on the ticker view: the *Configure* button collapsed onto the headline and the message form toolbar stacked vertically instead of forming a row.

The cause is that MUI 9 removed support for **system props**. Layout props passed directly to a component — `alignItems`, `justifyContent`, `display`, `flexGrow`, `mb` — are no longer turned into CSS and are forwarded to the DOM as attributes:

```html
<div class="MuiStack-root" alignitems="center" justifycontent="space-between" mb="2">
```

Moving them into `sx` restores the previous layout. `Typography` colours needed the same treatment: dotted palette paths such as `color="text.secondary"` are no longer resolved.

Auditing the rest of the upgrade surfaced more silent breakage:

* `Button` style overrides keyed by variant and colour (`containedInherit`, `containedPrimary`, …) no longer exist and are now expressed as style variants, which is what restores the button shadows.
* `CardHeader` takes `slotProps` for title and subheader typography; `Typography` lost its `paragraph` prop, making that override dead code.
* `Popover` takes `slotProps.paper` instead of `PaperProps`, `TextField` takes `slotProps.input` instead of `InputProps` — the latter dropped the phone icon from the Signal admin form.
* Opening the ticker list row menu threw `MenuListContext is missing`, because MUI 9's `MenuItem` requires a `MenuList`. The user list had already been fixed for this, the ticker list had not.

The last commit clears the remaining type errors from the React 19 and Node type upgrades (the global `JSX` namespace, `NodeJS.Timeout`, `useRef` without an initial value), so that `npm run tsc` passes again.

## Why it slipped through

`tsc` already flagged most of these as type errors, but no workflow runs it — `integration.yml` only tests and builds, and Vite's build does not type-check. Adding `npm run tsc` to CI would have caught the upgrade, and is worth doing in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)